### PR TITLE
Add client for geocoder api

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -13,9 +13,10 @@ type ServerConfig struct {
 		Name     string
 		Password string
 	} `mapstructure:"db_config"`
-	FirebaseSecret string `mapstructure:"firebase_secret"`
-	Mode           string
-	Port           string
+	FirebaseSecret   string `mapstructure:"firebase_secret"`
+	Mode             string
+	Port             string
+	GeocoderClientID string `mapstructure:"geocoder_client_id"`
 }
 
 const (

--- a/server/controllers/util.go
+++ b/server/controllers/util.go
@@ -1,0 +1,12 @@
+package controllers
+
+import (
+	"firebase.google.com/go/v4/auth"
+	"github.com/gin-gonic/gin"
+)
+
+func getUID(c *gin.Context) string {
+	token, _ := c.Get("token")
+	uid := token.(*auth.Token).UID
+	return uid
+}

--- a/server/geocoder/client.go
+++ b/server/geocoder/client.go
@@ -1,0 +1,101 @@
+package geocoder
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+const (
+	APIEndpoint = "https://map.yahooapis.jp/geocode/V1/geoCoder"
+)
+
+type Client struct {
+	httpClient *http.Client
+	clientID   string
+	endpoint   string
+}
+
+type Response struct {
+	ResultInfo struct {
+		Count       int
+		Total       int
+		Start       int
+		Status      int
+		Description string
+		Copyright   string
+		Latency     float32
+	}
+
+	Feature []struct {
+		Id       string
+		Name     string
+		Geometry struct {
+			Type        string
+			Coordinates CoordinateString
+		}
+		Property struct {
+			Uid        string
+			CassetteId string
+			Yomi       string
+			Country    struct {
+				Code string
+				Name string
+			}
+			Address              string
+			GovernmentCode       int
+			AddressMatchingLevel int
+		}
+	}
+}
+
+type RequestParam map[string]string
+type CoordinateString string
+type Coordinate struct {
+	Latitude  float32
+	Longitude float32
+}
+
+func New(clientID string) (*Client, error) {
+	if clientID == "" {
+		return nil, errors.New("missing client id")
+	}
+	c := &Client{
+		httpClient: http.DefaultClient,
+		clientID:   clientID,
+		endpoint:   APIEndpoint,
+	}
+	return c, nil
+}
+
+func (c Client) Search(params RequestParam) (*Response, error) {
+	var decodedResponse Response
+	request, err := http.NewRequest(http.MethodGet, c.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	query := request.URL.Query()
+	query.Set("appid", c.clientID)
+	for key, value := range params {
+		query.Set(key, value)
+	}
+	request.URL.RawQuery = query.Encode()
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	err = xml.NewDecoder(response.Body).Decode(&decodedResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &decodedResponse, nil
+
+}
+
+func (s CoordinateString) ToCoordinate() Coordinate {
+	var coordinate Coordinate
+	fmt.Sscanf(string(s), "%f,%f", &coordinate.Longitude, &coordinate.Latitude)
+	return coordinate
+}


### PR DESCRIPTION
# 概要
Yahoo!ジオコーダAPIをGoから使うクライアントを追加
https://developer.yahoo.co.jp/webapi/map/openlocalplatform/v1/geocoder.html


# 対応するIssue



# 修正内容の確認方法
APIキーが必要なので登録してから試してほしい

サンプルプログラム
```go
package main

import (
	"fmt"
	"github.com/youngeek-0410/mottake/server/geocoder"
	"log"
	"os"
)

func main() {
	clientID := os.Getenv("CLIENT_ID")
	client, err  := geocoder.New(clientID)
	if err != nil{
		log.Fatal(err)
	}
	address := "<Input address here>"
	response, err := client.Search(geocoder.RequestParam{"query": address})
	if err != nil{
		log.Fatal(err)
	}
	for _, result := range response.Feature{
		fmt.Println(result.Geometry.Coordinates.ToCoordinate())
	}


}
```


# レビューのポイント



# 備考

