### PR TITLE
fix yahoo api bug

### DIFF
--- a/server/controllers/util.go
+++ b/server/controllers/util.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"regexp"
 
 	"firebase.google.com/go/v4/auth"
@@ -58,6 +59,9 @@ func AddressToCoordinate(address string) (geocoder.Coordinate, error) {
 	response, err := client.Search(geocoder.RequestParam{"query": address})
 	if err != nil {
 		return init, err
+	}
+	if response.ResultInfo.Count <= 0 {
+		return init, errors.New("Result infomation is zero.")
 	}
 	result := response.Feature[0]
 	return result.Geometry.Coordinates.ToCoordinate(), nil


### PR DESCRIPTION
# 概要
<!-- 何がどう変わる変更なのか -->
住所が何もマッチしないときに配列の0番目を参照していてパニックが起きることがあったが、マッチした情報の数の確認を事前にすることで防ぐようにした。

# 対応するIssue
<!-- Issueへのリンクを貼る（例：#123） -->


# 修正内容の確認方法
<!-- 修正がどう反映されるかを確認する手順（あれば） -->


# レビューのポイント
<!-- レビュワーに特に見てほしいポイント（あれば） -->


# 備考
<!-- 他PR, issueとの兼ね合いやその他考慮が必要な事項（あれば） -->


<!-- 必ずしも全て埋めなくてよいが、必要な情報をわかりやすく書く。 -->
